### PR TITLE
fix: resolve 8 security and reliability bugs across payment and domain flows

### DIFF
--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -170,7 +170,8 @@ final class DomainController extends Controller
 
     public function domainInfo(Domain $domain, GetDomainInfoAction $action): Factory|View|\Illuminate\View\View
     {
-        abort_if(Gate::denies('domain_show'), 403) || $domain->owner_id !== auth()->id() && ! auth()->user()->isAdmin();
+        abort_if(Gate::denies('domain_show'), 403);
+
         if ($domain->owner_id !== auth()->id() && ! auth()->user()->isAdmin()) {
             return to_route('dashboard')->with('error', 'You are not authorized to view this domain.');
         }

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -42,6 +42,9 @@ final class CheckoutController extends Controller
                 ->with('error', 'Your cart is empty.');
         }
 
+        $order = null;
+        $paymentAttempt = null;
+
         try {
             $orderNumber = $this->generateOrderNumber();
             $cartTotal = Cart::getTotal();
@@ -72,14 +75,19 @@ final class CheckoutController extends Controller
             return redirect()->away($session->url);
 
         } catch (Exception $exception) {
-            $this->failPaymentAttempt($paymentAttempt, $exception->getMessage());
-            $this->transactionLogger->logFailure(
-                order: $order,
-                method: 'stripe',
-                error: 'Failed to create checkout session',
-                details: $exception->getMessage(),
-                payment: $paymentAttempt
-            );
+            if ($paymentAttempt !== null) {
+                $this->failPaymentAttempt($paymentAttempt, $exception->getMessage());
+            }
+
+            if ($order !== null) {
+                $this->transactionLogger->logFailure(
+                    order: $order,
+                    method: 'stripe',
+                    error: 'Failed to create checkout session',
+                    details: $exception->getMessage(),
+                    payment: $paymentAttempt
+                );
+            }
             Log::error('Failed to create checkout session', [
                 'error' => $exception->getMessage(),
                 'user_id' => auth()->id(),

--- a/app/Http/Controllers/KPayWebhookController.php
+++ b/app/Http/Controllers/KPayWebhookController.php
@@ -10,6 +10,7 @@ use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 final class KPayWebhookController extends Controller
@@ -87,13 +88,8 @@ final class KPayWebhookController extends Controller
                     ]);
                 }
 
-                // Update payment and order status
-                $this->kPayPaymentStatusService->updatePaymentStatus(
-                    $payment,
-                    $order,
-                    $statusid,
-                    $data
-                );
+                // Update payment and order status atomically
+                DB::transaction(fn () => $this->kPayPaymentStatusService->updatePaymentStatus($payment, $order, $statusid, $data));
 
                 // Process successful payment (dispatch jobs in background)
                 try {
@@ -125,13 +121,8 @@ final class KPayWebhookController extends Controller
             }
 
             if ($this->kPayPaymentStatusService->isFailedStatus($statusid)) {
-                // Update payment and order status
-                $this->kPayPaymentStatusService->updatePaymentStatus(
-                    $payment,
-                    $order,
-                    $statusid,
-                    $data
-                );
+                // Update payment and order status atomically
+                DB::transaction(fn () => $this->kPayPaymentStatusService->updatePaymentStatus($payment, $order, $statusid, $data));
 
                 $order->refresh();
                 $payment->refresh();

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -153,11 +153,15 @@ final class PaymentController extends Controller
                         ->with('error', 'Payment was not successful.');
                 }
 
-                // Only process if order is still pending payment
-                if ($order->payment_status === 'pending') {
-                    DB::beginTransaction();
+                // Lock the order row and check status atomically to prevent duplicate processing
+                $orderWasProcessed = false;
 
-                    try {
+                DB::beginTransaction();
+
+                try {
+                    $order = Order::query()->lockForUpdate()->findOrFail($order->id);
+
+                    if ($order->payment_status === 'pending') {
                         $order->update([
                             'payment_status' => 'paid',
                             'status' => $order->status === 'pending' ? 'processing' : $order->status,
@@ -193,45 +197,49 @@ final class PaymentController extends Controller
                             ]);
                         }
 
-                        DB::commit();
+                        $orderWasProcessed = true;
+                    }
 
-                        // Process order after payment (idempotent - safe to call multiple times)
-                        try {
-                            $primaryContact = $order->user->contacts()->where('is_primary', true)->first();
-                            $contactIds = [];
-                            if ($primaryContact) {
-                                $contactIds = [
-                                    'registrant' => $primaryContact->id,
-                                    'admin' => $primaryContact->id,
-                                    'tech' => $primaryContact->id,
-                                    'billing' => $primaryContact->id,
-                                ];
-                            }
+                    DB::commit();
+                } catch (Exception $e) {
+                    DB::rollBack();
+                    Log::error('Failed to update order on success page', [
+                        'order_id' => $order->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                    // Continue to show success page even if update fails
+                }
 
-                            $processOrderAction = resolve(ProcessOrderAfterPaymentAction::class);
-                            $processOrderAction->handle($order, $contactIds, false);
-
-                            Log::info('Order processed successfully on success page', [
-                                'order_id' => $order->id,
-                                'order_number' => $order->order_number,
-                            ]);
-                        } catch (Exception $e) {
-                            Log::warning('Order processing failed on success page', [
-                                'order_id' => $order->id,
-                                'error' => $e->getMessage(),
-                            ]);
-                            // Don't fail the page load if processing fails - webhook will handle it
+                if ($orderWasProcessed) {
+                    // Process order after payment (idempotent - safe to call multiple times)
+                    try {
+                        $primaryContact = $order->user->contacts()->where('is_primary', true)->first();
+                        $contactIds = [];
+                        if ($primaryContact) {
+                            $contactIds = [
+                                'registrant' => $primaryContact->id,
+                                'admin' => $primaryContact->id,
+                                'tech' => $primaryContact->id,
+                                'billing' => $primaryContact->id,
+                            ];
                         }
 
-                        $order->refresh();
+                        $processOrderAction = resolve(ProcessOrderAfterPaymentAction::class);
+                        $processOrderAction->handle($order, $contactIds, false);
+
+                        Log::info('Order processed successfully on success page', [
+                            'order_id' => $order->id,
+                            'order_number' => $order->order_number,
+                        ]);
                     } catch (Exception $e) {
-                        DB::rollBack();
-                        Log::error('Failed to update order on success page', [
+                        Log::warning('Order processing failed on success page', [
                             'order_id' => $order->id,
                             'error' => $e->getMessage(),
                         ]);
-                        // Continue to show success page even if update fails
+                        // Don't fail the page load if processing fails - webhook will handle it
                     }
+
+                    $order->refresh();
                 }
             } catch (ApiErrorException $e) {
                 Log::error('Failed to retrieve Stripe session on success page', [

--- a/app/Jobs/ProcessDomainRegistrationJob.php
+++ b/app/Jobs/ProcessDomainRegistrationJob.php
@@ -10,6 +10,7 @@ use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 final class ProcessDomainRegistrationJob implements ShouldQueue
 {
@@ -32,6 +33,23 @@ final class ProcessDomainRegistrationJob implements ShouldQueue
         public Order $order,
         public array $contactIds = []
     ) {}
+
+    /**
+     * Handle a job failure after all retries are exhausted.
+     */
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Domain registration job permanently failed after all retries', [
+            'order_id' => $this->order->id,
+            'order_number' => $this->order->order_number,
+            'error' => $exception->getMessage(),
+        ]);
+
+        $this->order->update([
+            'status' => 'failed',
+            'notes' => 'Domain registration permanently failed after all retries: '.$exception->getMessage(),
+        ]);
+    }
 
     /**
      * Execute the job.

--- a/database/migrations/2026_04_06_172455_fix_payments_amount_column_type.php
+++ b/database/migrations/2026_04_06_172455_fix_payments_amount_column_type.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            $table->decimal('amount', 10, 2)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            $table->integer('amount')->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_06_172459_add_cascade_delete_to_domain_contacts_table.php
+++ b/database/migrations/2026_04_06_172459_add_cascade_delete_to_domain_contacts_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Drop existing foreign keys and recreate with cascade delete
+        Schema::table('domain_contacts', function (Illuminate\Database\Schema\Blueprint $table): void {
+            $table->dropForeign(['domain_id']);
+            $table->dropForeign(['contact_id']);
+            $table->dropForeign(['user_id']);
+
+            $table->foreign('domain_id')->references('id')->on('domains')->cascadeOnDelete();
+            $table->foreign('contact_id')->references('id')->on('contacts')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('domain_contacts', function (Illuminate\Database\Schema\Blueprint $table): void {
+            $table->dropForeign(['domain_id']);
+            $table->dropForeign(['contact_id']);
+            $table->dropForeign(['user_id']);
+
+            $table->foreign('domain_id')->references('id')->on('domains');
+            $table->foreign('contact_id')->references('id')->on('contacts');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+};

--- a/resources/views/domains/register.blade.php
+++ b/resources/views/domains/register.blade.php
@@ -469,7 +469,7 @@
                                         <li class="list-group-item">
                                             {{ $item->name }}
                                             <p class="float-right">
-                                                {!! $converted['formatted_line_total'] !!}
+                                                {{ $converted['formatted_line_total'] }}
                                                 / {{ $converted['quantity'] }} {{ Str::plural('Year', $converted['quantity']) }}
                                             </p>
                                         </li>
@@ -479,7 +479,7 @@
                                         <b>Total</b>
                                         <b>
                                             <p class="float-right">
-                                                {!! $convertedCartTotal !!}
+                                                {{ $convertedCartTotal }}
                                             </p>
                                         </b>
                                     </li>


### PR DESCRIPTION
## Summary

- **XSS fix**: Escape cart price output in `register.blade.php` (`{!! !!}` → `{{ }}`)
- **Undefined variables**: Initialize `$order`/`$paymentAttempt` to `null` in `CheckoutController` before the try block to prevent secondary errors on early exceptions
- **Race condition**: Lock order row with `lockForUpdate()` inside a transaction in `PaymentController::success()` before checking `payment_status`, preventing duplicate payment processing
- **Atomic webhook updates**: Wrap both `updatePaymentStatus()` calls in `KPayWebhookController` with `DB::transaction()` so payment and order rows update atomically
- **Job failure handling**: Add `failed()` handler to `ProcessDomainRegistrationJob` so permanently failed jobs mark the order as `failed` instead of silently stopping at `requires_attention`
- **Dead code removal**: Remove unreachable `|| ...` expression in `Admin\DomainController::domainInfo()` authorization check
- **Migration**: Change `payments.amount` from `integer` to `decimal(10,2)` to prevent precision loss on fractional amounts
- **Migration**: Add `cascadeOnDelete` to all three foreign keys on `domain_contacts` to prevent orphaned pivot rows

## Test plan

- [x] Verify checkout still redirects to Stripe when cart is non-empty
- [x] Simulate an early exception in `CheckoutController::index()` (e.g. DB down) — should log cleanly without a secondary undefined variable error
- [x] Confirm simultaneous Stripe webhook + success-page requests do not double-process an order
- [x] Trigger a KPay postback and verify both payment and order rows update together (or neither)
- [x] Force `ProcessDomainRegistrationJob` to exhaust retries — order should move to `failed` status
- [x] Run `php artisan migrate` and verify both new migrations apply cleanly
- [x] Confirm cart price totals still display correctly on the domain register page

🤖 Generated with [Claude Code](https://claude.com/claude-code)