### PR TITLE
fix: resolve select2 select-all/deselect-all and variable shadowing in roles CRUD

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -39,14 +39,14 @@ $(document).ready(function () {
     })
 
     $('.select-all').click(function () {
-        let $select2 = $(this).parent().siblings('.select2')
-        $select2.find('option').prop('selected', 'selected')
-        $select2.trigger('change')
+        let $select = $(this).parent().siblings('select')
+        $select.find('option').prop('selected', 'selected')
+        $select.trigger('change')
     })
     $('.deselect-all').click(function () {
-        let $select2 = $(this).parent().siblings('.select2')
-        $select2.find('option').prop('selected', '')
-        $select2.trigger('change')
+        let $select = $(this).parent().siblings('select')
+        $select.find('option').prop('selected', '')
+        $select.trigger('change')
     })
 
     $('.select2').select2()

--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -24,8 +24,8 @@
                         <span class="btn btn-info btn-xs select-all">{{ trans('global.select_all') }}</span>
                         <span class="btn btn-info btn-xs deselect-all">{{ trans('global.deselect_all') }}</span></label>
                     <select name="permissions[]" id="permissions" class="form-control select2bs4" multiple="multiple" required>
-                        @foreach($permissions as $id => $permissions)
-                            <option value="{{ $id }}" {{ (in_array($id, old('permissions', [])) || isset($role) && $role->permissions->contains($id)) ? 'selected' : '' }}>{{ $permissions }}</option>
+                        @foreach($permissions as $id => $permission)
+                            <option value="{{ $id }}" {{ (in_array($id, old('permissions', [])) || isset($role) && $role->permissions->contains($id)) ? 'selected' : '' }}>{{ $permission }}</option>
                         @endforeach
                     </select>
                     @if($errors->has('permissions'))

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -25,8 +25,8 @@
                         <span class="btn btn-info btn-xs select-all">{{ trans('global.select_all') }}</span>
                         <span class="btn btn-info btn-xs deselect-all">{{ trans('global.deselect_all') }}</span></label>
                     <select name="permissions[]" id="permissions" class="form-control select2bs4" multiple="multiple" required>
-                        @foreach($permissions as $id => $permissions)
-                            <option value="{{ $id }}" {{ (in_array($id, old('permissions', [])) || isset($role) && $role->permissions->contains($id)) ? 'selected' : '' }}>{{ $permissions }}</option>
+                        @foreach($permissions as $id => $permission)
+                            <option value="{{ $id }}" {{ (in_array($id, old('permissions', [])) || isset($role) && $role->permissions->contains($id)) ? 'selected' : '' }}>{{ $permission }}</option>
                         @endforeach
                     </select>
                     @if($errors->has('permissions'))

--- a/tests/Feature/Admin/RolesCrudTest.php
+++ b/tests/Feature/Admin/RolesCrudTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\AuthGates;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+function createRoleAdminUser(): User
+{
+    $role = Role::query()->create(['title' => 'RoleAdmin-'.uniqid()]);
+    foreach (['role_access', 'role_create', 'role_edit', 'role_show', 'role_delete'] as $perm) {
+        $role->permissions()->attach(
+            Permission::query()->where('title', $perm)->first()?->id
+                ?? Permission::query()->create(['title' => $perm])->id
+        );
+    }
+    $user = User::factory()->create();
+    $user->roles()->attach($role);
+
+    return $user;
+}
+
+function setupRoleAdminGates(User $user): void
+{
+    auth()->login($user);
+    (new AuthGates)->handle(Request::create('/'), fn ($req) => $req);
+}
+
+it('renders the create role page with permissions options', function (): void {
+    $user = createRoleAdminUser();
+    setupRoleAdminGates($user);
+
+    $permission = Permission::query()->create(['title' => 'some_permission']);
+
+    $response = $this->actingAs($user)->get(route('admin.roles.create'));
+
+    $response->assertOk();
+    $response->assertSee($permission->title);
+});
+
+it('stores a new role with permissions', function (): void {
+    $user = createRoleAdminUser();
+    setupRoleAdminGates($user);
+
+    $permission = Permission::query()->create(['title' => 'test_perm_'.uniqid()]);
+
+    $response = $this->actingAs($user)->post(route('admin.roles.store'), [
+        'title' => 'Test Role',
+        'permissions' => [$permission->id],
+    ]);
+
+    $response->assertRedirect(route('admin.roles.index'));
+
+    $role = Role::query()->where('title', 'Test Role')->first();
+    expect($role)->not->toBeNull()
+        ->and($role->permissions->contains($permission->id))->toBeTrue();
+});
+
+it('renders the edit role page with pre-selected permissions', function (): void {
+    $user = createRoleAdminUser();
+    setupRoleAdminGates($user);
+
+    $permission = Permission::query()->create(['title' => 'edit_perm_'.uniqid()]);
+    $role = Role::query()->create(['title' => 'Editable Role']);
+    $role->permissions()->attach($permission->id);
+
+    $response = $this->actingAs($user)->get(route('admin.roles.edit', $role));
+
+    $response->assertOk();
+    $response->assertSee($permission->title);
+    $response->assertSee('selected', false);
+});
+
+it('updates a role with new permissions', function (): void {
+    $user = createRoleAdminUser();
+    setupRoleAdminGates($user);
+
+    $oldPermission = Permission::query()->create(['title' => 'old_perm_'.uniqid()]);
+    $newPermission = Permission::query()->create(['title' => 'new_perm_'.uniqid()]);
+    $role = Role::query()->create(['title' => 'Role To Update']);
+    $role->permissions()->attach($oldPermission->id);
+
+    $response = $this->actingAs($user)->put(route('admin.roles.update', $role), [
+        'title' => 'Updated Role',
+        'permissions' => [$newPermission->id],
+    ]);
+
+    $response->assertRedirect(route('admin.roles.index'));
+
+    $role->refresh()->load('permissions');
+    expect($role->title)->toBe('Updated Role')
+        ->and($role->permissions->contains($newPermission->id))->toBeTrue()
+        ->and($role->permissions->contains($oldPermission->id))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- **select-all / deselect-all buttons were broken** — `main.js` was traversing to the Select2 wrapper `<span class="select2">` and calling `.find('option')` on it. Select2's container has no `<option>` elements (they stay in the hidden original `<select>`), so toggling did nothing. Fixed by targeting `.siblings('select')` instead.
- **Variable shadowing in `@foreach`** — both `create.blade.php` and `edit.blade.php` used `$permissions` as the loop variable, silently overwriting the outer `$permissions` collection. Renamed loop variable to `$permission`.
- **Added feature tests** covering create, store, edit, and update role flows to prevent regressions.

## Test plan

- [ ] Visit `/admin/roles/create` — verify the Select All / Deselect All buttons correctly select and clear all permission options
- [ ] Submit the create form with validation errors — verify permissions list still renders correctly
- [ ] Visit `/admin/roles/{id}/edit` — verify pre-selected permissions appear and Select All / Deselect All work
- [ ] Run `php artisan test --compact --filter=RolesCrudTest` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)