### PR TITLE
fix: move select-all/deselect-all buttons outside label in roles forms

### DIFF
--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -20,9 +20,11 @@
                     </p>
                 </div>
                 <div class="form-group {{ $errors->has('permissions') ? 'has-error' : '' }}">
-                    <label for="permissions">{{ trans('cruds.role.fields.permissions') }}*
-                        <span class="btn btn-info btn-xs select-all">{{ trans('global.select_all') }}</span>
-                        <span class="btn btn-info btn-xs deselect-all">{{ trans('global.deselect_all') }}</span></label>
+                    <label for="permissions">{{ trans('cruds.role.fields.permissions') }}*</label>
+                    <div style="padding-bottom: 4px">
+                        <span class="btn btn-info btn-xs select-all" style="border-radius: 0">{{ trans('global.select_all') }}</span>
+                        <span class="btn btn-info btn-xs deselect-all" style="border-radius: 0">{{ trans('global.deselect_all') }}</span>
+                    </div>
                     <select name="permissions[]" id="permissions" class="form-control select2bs4" multiple="multiple" required>
                         @foreach($permissions as $id => $permission)
                             <option value="{{ $id }}" {{ (in_array($id, old('permissions', [])) || isset($role) && $role->permissions->contains($id)) ? 'selected' : '' }}>{{ $permission }}</option>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -21,9 +21,11 @@
                     </p>
                 </div>
                 <div class="form-group {{ $errors->has('permissions') ? 'has-error' : '' }}">
-                    <label for="permissions">{{ trans('cruds.role.fields.permissions') }}*
-                        <span class="btn btn-info btn-xs select-all">{{ trans('global.select_all') }}</span>
-                        <span class="btn btn-info btn-xs deselect-all">{{ trans('global.deselect_all') }}</span></label>
+                    <label for="permissions">{{ trans('cruds.role.fields.permissions') }}*</label>
+                    <div style="padding-bottom: 4px">
+                        <span class="btn btn-info btn-xs select-all" style="border-radius: 0">{{ trans('global.select_all') }}</span>
+                        <span class="btn btn-info btn-xs deselect-all" style="border-radius: 0">{{ trans('global.deselect_all') }}</span>
+                    </div>
                     <select name="permissions[]" id="permissions" class="form-control select2bs4" multiple="multiple" required>
                         @foreach($permissions as $id => $permission)
                             <option value="{{ $id }}" {{ (in_array($id, old('permissions', [])) || isset($role) && $role->permissions->contains($id)) ? 'selected' : '' }}>{{ $permission }}</option>
@@ -42,8 +44,6 @@
                     <input class="btn btn-danger" type="submit" value="{{ trans('global.save') }}">
                 </div>
             </form>
-
-
         </div>
     </div>
 </x-admin-layout>

--- a/tests/Feature/Admin/RolesCrudTest.php
+++ b/tests/Feature/Admin/RolesCrudTest.php
@@ -41,6 +41,18 @@ it('renders the create role page with permissions options', function (): void {
     $response->assertSee($permission->title);
 });
 
+it('renders select-all and deselect-all buttons outside the label on create page', function (): void {
+    $user = createRoleAdminUser();
+    setupRoleAdminGates($user);
+
+    $response = $this->actingAs($user)->get(route('admin.roles.create'));
+
+    $response->assertOk();
+    $response->assertSee('select-all', false);
+    $response->assertSee('deselect-all', false);
+    $response->assertSee('padding-bottom: 4px', false);
+});
+
 it('stores a new role with permissions', function (): void {
     $user = createRoleAdminUser();
     setupRoleAdminGates($user);
@@ -72,6 +84,20 @@ it('renders the edit role page with pre-selected permissions', function (): void
     $response->assertOk();
     $response->assertSee($permission->title);
     $response->assertSee('selected', false);
+});
+
+it('renders select-all and deselect-all buttons outside the label on edit page', function (): void {
+    $user = createRoleAdminUser();
+    setupRoleAdminGates($user);
+
+    $role = Role::query()->create(['title' => 'Some Role']);
+
+    $response = $this->actingAs($user)->get(route('admin.roles.edit', $role));
+
+    $response->assertOk();
+    $response->assertSee('select-all', false);
+    $response->assertSee('deselect-all', false);
+    $response->assertSee('padding-bottom: 4px', false);
 });
 
 it('updates a role with new permissions', function (): void {


### PR DESCRIPTION
Buttons nested inside <label for="permissions"> caused the browser to also trigger the label's associated-control activation when clicked, opening the Select2 dropdown simultaneously with the select-all action. Restructured to match the working pattern in users/create.blade.php.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the permissions field layout in role management pages, improving visual clarity and component structure by separating action controls from the label area.

* **Tests**
  * Added test coverage to verify the permissions field UI structure is rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->