### PR TITLE
fix: move @push('scripts') inside x-admin-layout in roles views

### DIFF
--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -45,15 +45,15 @@
             </form>
         </div>
     </div>
-</x-admin-layout>
 
-@push('scripts')
-<script>
-    $(function () {
-        $('.select2bs4').select2({
-            theme: 'bootstrap4',
-            width: '100%'
-        });
-    });
-</script>
-@endpush
+    @push('scripts')
+        <script>
+            $(function () {
+                $('.select2bs4').select2({
+                    theme: 'bootstrap4',
+                    width: '100%'
+                });
+            });
+        </script>
+    @endpush
+</x-admin-layout>

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -46,15 +46,15 @@
             </form>
         </div>
     </div>
-</x-admin-layout>
 
-@push('scripts')
-<script>
-    $(function () {
-        $('.select2bs4').select2({
-            theme: 'bootstrap4',
-            width: '100%'
-        });
-    });
-</script>
-@endpush
+    @push('scripts')
+        <script>
+            $(function () {
+                $('.select2bs4').select2({
+                    theme: 'bootstrap4',
+                    width: '100%'
+                });
+            });
+        </script>
+    @endpush
+</x-admin-layout>


### PR DESCRIPTION
@push('scripts') placed after </x-admin-layout> ran after @stack('scripts') had already been rendered, so Select2 was never initialized. Moved the block inside the component tags to match the pattern used in users/create.