### PR TITLE
fix: use Select2 val() API and robust traversal in select-all handlers

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -39,14 +39,13 @@ $(document).ready(function () {
     })
 
     $('.select-all').click(function () {
-        let $select = $(this).parent().siblings('select')
-        $select.find('option').prop('selected', 'selected')
-        $select.trigger('change')
+        let $select = $(this).closest('.form-group').find('select')
+        let allValues = $select.find('option').map(function () { return this.value }).get()
+        $select.val(allValues).trigger('change')
     })
     $('.deselect-all').click(function () {
-        let $select = $(this).parent().siblings('select')
-        $select.find('option').prop('selected', '')
-        $select.trigger('change')
+        let $select = $(this).closest('.form-group').find('select')
+        $select.val([]).trigger('change')
     })
 
     $('.select2').select2()


### PR DESCRIPTION
.prop('selected') + trigger('change') is unreliable with Select2. Replace with .val([values]).trigger('change') and .val([]).trigger('change'), which are the officially supported Select2 programmatic update methods. Also use .closest('.form-group').find('select') instead of .parent().siblings('select') for a traversal that works regardless of button nesting depth.