### PR TITLE
fix: prevent price activation when is_current submitted as "0" from browser

### DIFF
--- a/app/Actions/Hosting/PlanPrices/UpdatePlanPriceAction.php
+++ b/app/Actions/Hosting/PlanPrices/UpdatePlanPriceAction.php
@@ -6,7 +6,7 @@ namespace App\Actions\Hosting\PlanPrices;
 
 use App\Jobs\ActivateHostingPlanPriceJob;
 use App\Models\HostingPlanPrice;
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Facades\Date;
 
 final readonly class UpdatePlanPriceAction
@@ -48,8 +48,8 @@ final readonly class UpdatePlanPriceAction
     private function handleFutureEffectiveDate(
         HostingPlanPrice $planPrice,
         array $data,
-        Carbon $effectiveDate,
-        Carbon $today
+        CarbonInterface $effectiveDate,
+        CarbonInterface $today
     ): void {
         $data['is_current'] = false;
         $planPrice->update($data);
@@ -66,7 +66,7 @@ final readonly class UpdatePlanPriceAction
         $planPrice->update($data);
         $planPrice->refresh();
 
-        $shouldActivate = ($data['is_current'] ?? true) !== false && ! $planPrice->is_current;
+        $shouldActivate = (bool) ($data['is_current'] ?? true) && ! $planPrice->is_current;
 
         if ($shouldActivate) {
             $this->activateAction->handle($planPrice);

--- a/tests/Feature/Feature/Admin/HostingPlanPriceCrudTest.php
+++ b/tests/Feature/Feature/Admin/HostingPlanPriceCrudTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\Hosting\BillingCycle;
+use App\Jobs\ActivateHostingPlanPriceJob;
 use App\Models\Currency;
 use App\Models\HostingCategory;
 use App\Models\HostingPlan;
@@ -12,6 +13,7 @@ use App\Models\Role;
 use App\Models\User;
 use Database\Seeders\PermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 
 uses(RefreshDatabase::class);
 
@@ -175,6 +177,28 @@ test('store validates is_current and effective_date required', function (): void
 
 // --- Update ---
 
+test('update with is_current "0" string does not activate price', function (): void {
+    $user = createPriceAdmin(['hosting_plan_price_edit']);
+    $price = makePlanPrice(['is_current' => true]);
+
+    $response = $this->actingAs($user)
+        ->patch(route('admin.hosting-plan-prices.update', $price->uuid), [
+            'hosting_category_id' => $price->plan->category_id,
+            'hosting_plan_id' => $price->hosting_plan_id,
+            'currency_id' => $price->currency_id,
+            'billing_cycle' => $price->billing_cycle,
+            'regular_price' => $price->regular_price,
+            'renewal_price' => $price->renewal_price,
+            'status' => 'active',
+            'is_current' => '0',
+            'effective_date' => now()->subDay()->format('Y-m-d'),
+        ]);
+
+    $response->assertRedirect(route('admin.hosting-plan-prices.index'));
+    $price->refresh();
+    expect($price->is_current)->toBeFalse();
+});
+
 test('update works with new fields', function (): void {
     $user = createPriceAdmin(['hosting_plan_price_edit']);
     $price = makePlanPrice();
@@ -263,6 +287,31 @@ test('update with price change and reason succeeds', function (): void {
 
     $price->refresh();
     expect((float) $price->regular_price)->toBe(20.00);
+});
+
+test('update with future effective date sets is_current to false without throwing', function (): void {
+    Bus::fake();
+
+    $user = createPriceAdmin(['hosting_plan_price_edit']);
+    $price = makePlanPrice();
+
+    $response = $this->actingAs($user)
+        ->patch(route('admin.hosting-plan-prices.update', $price->uuid), [
+            'hosting_category_id' => $price->plan->category_id,
+            'hosting_plan_id' => $price->hosting_plan_id,
+            'currency_id' => $price->currency_id,
+            'billing_cycle' => $price->billing_cycle,
+            'regular_price' => $price->regular_price,
+            'renewal_price' => $price->renewal_price,
+            'status' => 'active',
+            'is_current' => true,
+            'effective_date' => now()->addDays(5)->format('Y-m-d'),
+        ]);
+
+    $response->assertRedirect(route('admin.hosting-plan-prices.index'));
+    Bus::assertDispatched(ActivateHostingPlanPriceJob::class);
+    $price->refresh();
+    expect($price->is_current)->toBeFalse();
 });
 
 // --- Delete ---


### PR DESCRIPTION
## Summary

- Fixed a bug in `UpdatePlanPriceAction` where selecting "No" for the Current field in the edit form still triggered `ActivateHostingPlanPriceAction`, incorrectly marking the price as current
- The root cause was a strict `!== false` comparison that treated the string `"0"` (what HTML `<select>` forms submit) as truthy — `"0" !== false` is `true` in PHP
- Changed to `(bool)` cast which correctly handles all boolean-like inputs (`"0"`, `"1"`, `true`, `false`)
- Also broadens Carbon type hints to `CarbonInterface` for better compatibility

## Test plan

- [x] New test `update with is_current "0" string does not activate price` reproduces the browser scenario by passing `'is_current' => '0'` (string) — would have failed before the fix
- [x] New test `update with future effective date sets is_current to false without throwing` covers the job dispatch path
- [x] All 19 existing tests continue to pass (`php artisan test --compact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for determining when hosting plan price updates should take effect

* **Tests**
  * Added test coverage for scheduling hosting plan price updates with future effective dates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->